### PR TITLE
pickup sounds and slightly change on small skeleton collider position

### DIFF
--- a/Assets/Prefabs/Monsters/EnemySkeletonMinionTiny.prefab
+++ b/Assets/Prefabs/Monsters/EnemySkeletonMinionTiny.prefab
@@ -125,7 +125,7 @@ PrefabInstance:
     - target: {fileID: 4095870015713098343, guid: d28ab01b54ed6ed4eb816bcd7dc6deea,
         type: 3}
       propertyPath: m_Center.x
-      value: -1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4095870015713098343, guid: d28ab01b54ed6ed4eb816bcd7dc6deea,
         type: 3}

--- a/Assets/Prefabs/Monsters/EnemySkeletonMinionTiny.prefab
+++ b/Assets/Prefabs/Monsters/EnemySkeletonMinionTiny.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4095870015713098343, guid: d28ab01b54ed6ed4eb816bcd7dc6deea,
         type: 3}
+      propertyPath: m_Center.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4095870015713098343, guid: d28ab01b54ed6ed4eb816bcd7dc6deea,
+        type: 3}
       propertyPath: m_Center.y
       value: 2
       objectReference: {fileID: 0}

--- a/Assets/Scripts/Pickups/ExperienceOrbPickup.cs
+++ b/Assets/Scripts/Pickups/ExperienceOrbPickup.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 
 public class ExperienceOrbPickup : Pickup
 {
+    // cache reference for easier access
+    private static AudioManager audioManager => AudioManager.Instance;
     public float Experience;
 
     protected override bool HandlePickUpImpl(GameObject target)
@@ -9,7 +11,7 @@ public class ExperienceOrbPickup : Pickup
         var asc = target.GetComponent<AbilitySystemComponent>();
         if (asc == null)
             return false;
-
+        audioManager.PlaySFX(audioManager.grabExperienceSound);
         asc.AddExperience(Experience);
 
         return true;

--- a/Assets/Scripts/Pickups/Pickup.cs
+++ b/Assets/Scripts/Pickups/Pickup.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 public class Pickup : MonoBehaviour
 {
+
     public delegate void PickedUpDelegate(Pickup pickup, GameObject pickedUpBy);
 
     public static GameObject GetPickupGameObject(Component context)

--- a/Assets/Scripts/Pickups/PickupWithEffect.cs
+++ b/Assets/Scripts/Pickups/PickupWithEffect.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 public class PickupWithEffect : Pickup
 {
+    // cache reference for easier access
+    private static AudioManager audioManager => AudioManager.Instance;
+
     public Effect Effect;
 
     protected override bool HandlePickUpImpl(GameObject target)
@@ -10,6 +13,7 @@ public class PickupWithEffect : Pickup
         if (asc == null)
             return false;
 
+        audioManager.PlaySFX(audioManager.grabExperienceSound);
         asc.ApplyEffectToSelf(Effect);
 
         return true;

--- a/Assets/Scripts/Pickups/WeaponPickup.cs
+++ b/Assets/Scripts/Pickups/WeaponPickup.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 public class WeaponPickup : Pickup
 {
+    // cache reference for easier access
+    private static AudioManager audioManager => AudioManager.Instance;
+
     public WeaponItem WeaponItem;
 
     protected override bool HandlePickUpImpl(GameObject target)
@@ -14,6 +17,7 @@ public class WeaponPickup : Pickup
         {
             // auto equip
             equipmentComponent.EquipItem(WeaponItem);
+            audioManager.PlaySFX(audioManager.grabExperienceSound);
             return true;
         }
 


### PR DESCRIPTION
I have added a sound for picking up objects. For now they are the same for orbs, weapons and abilities, but can be easily made different. The clip is a simple coin grabbing sound, let me know if you guys like it. 

I have also spent time looking into the aiming issue. It is not simple to solve, at least for me. I think the issue derives from moving the shoot so it sorts from the weapon´s nozzle and not from the center of our player, as Johann explained to me. But solving it is very challenging. So, to mitigate a bit the problem, I moved the small skeleton collider just a little bit to the right. It seems this improves the situation. If not, we can increase a bit its size, can you please check and let me know what do you think?